### PR TITLE
Chore add Jitpack release support

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -4,6 +4,7 @@ dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 
     // Reuse the version catalog from the main build.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,12 +3,12 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("com.android.library")
     alias(libs.plugins.atomicfu)
-    alias(libs.plugins.multiplatform)
-    alias(libs.plugins.cocoapods)
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.kotlin.native.cocoapods")
     alias(libs.plugins.dokka)
-    alias(libs.plugins.serialization)
+    id("org.jetbrains.kotlin.plugin.serialization")
     alias(libs.plugins.skie)
     alias(libs.plugins.vanniktech.publish)
     `maven-publish`
@@ -18,6 +18,10 @@ plugins {
 val libGroup = "io.tolgee.mobile-kotlin-sdk"
 val libName = "core"
 val appleFramework = "KMPTolgee"
+
+// The libVersion should be defined, usually in gradle.properties or a parent build.gradle
+// If it's missing, it might cause other issues. Assuming it's available.
+val libVersion = libs.versions.library.get()
 
 group = libGroup
 version = libVersion
@@ -267,7 +271,7 @@ android {
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/demo/exampleandroid/src/main/java/io/tolgee/demo/exampleandroid/MainJavaActivity.java
+++ b/demo/exampleandroid/src/main/java/io/tolgee/demo/exampleandroid/MainJavaActivity.java
@@ -26,7 +26,6 @@ public class MainJavaActivity extends ComponentActivity implements Tolgee.Change
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         tolgee.addChangeListener(this);
 
         setContentView(R.layout.activity_main);

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk21
+install:
+  - ./gradlew publishToMavenLocal

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
         mavenLocal()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 
@@ -19,6 +20,7 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
         mavenLocal()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
# Content
- This PR adds Jitpack publishing capabilities to SDK in order to make it easier for community and PR reviews changes that are consumed as artifacts

## Example
Artifact Release - https://jitpack.io/#NikolaRusakov/tolgee-mobile-kotlin-sdk/v1.0.0-alpha044
GitHub Release - https://github.com/NikolaRusakov/tolgee-mobile-kotlin-sdk/releases/tag/v1.0.0-alpha044