### PR TITLE
Extend CDN configuration capabilities

### DIFF
--- a/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
+++ b/core/src/commonMain/kotlin/io/tolgee/Tolgee.kt
@@ -273,7 +273,7 @@ open class Tolgee(
         if (config.availableLocales != null) return
 
         // Skip if already loaded
-        if (cachedManifest.value != null) return
+        if (cachedManifest.value?.locales != null) return
 
         withContext(config.network.context) {
             // Try to fetch fresh manifest from CDN
@@ -888,7 +888,7 @@ open class Tolgee(
             val path: (language: String) -> String = { "$it.json" },
             val storage: TolgeeStorageProvider? = platformStorage,
             val formatter: Formatter = Formatter.Sprintf,
-            val manifestPath: String = path("manifest"),
+            val manifestPath: String = "manifest.json",
             val maxLocalesInMemory: Int? = 1,
         ) {
             /**
@@ -1069,7 +1069,7 @@ open class Tolgee(
                 fun build(): ContentDelivery = ContentDelivery(
                     url = url?.ifBlank { null },
                     path = path,
-                    manifestPath = manifestPath ?: path("manifest"),
+                    manifestPath = manifestPath ?: "manifest.json",
                     storage = storage,
                     formatter = formatter,
                     maxLocalesInMemory = maxLocalesInMemory


### PR DESCRIPTION
# Content

As a part of broader integration with open source repositories that adapted Tolgee SDK, the content CDN language mapping and manifest.json file prevented consuming static XML files from Tolgee Platform.


1. This was observed when using `https://app.tolgee.io/projects/29352/integrate` project which suggests setting up `.tolgeerc` config file and pushing the current `strings.xml`, this required custom paths for real life projects.
1. It was also observed that `availableLocales(availableLocales)` needed to be provided in `Tolgee.init`

During debugging session it see observed that when  cached manifest option for locales wasn't provided in `Tolgee.init` 
  https://github.com/NikolaRusakov/tolgee-mobile-kotlin-sdk/compare/feature/add-real-world-examples#diff-89dd2512191d99f1bad25149615c5615fdee683679fe63754624194879ba2084R13-R32
 The configuration would fail.

# Fix for statically consumed as other formats from Tolgee Platform

- preventing reuse of inline function `val path: (language: String) -> String = { "$it.json" },`  allowed defining path that differs with following platform configuration:
<img width="911" height="292" alt="Screenshot From 2026-06-30 21-12-08" src="https://github.com/user-attachments/assets/02f81855-d788-4bbb-bc0b-2ece74e1e1cc" />
